### PR TITLE
feat: Create IAM user for Grafana to use to read CloudWatch [DEV-164]

### DIFF
--- a/06_monitoring.cfn.yml
+++ b/06_monitoring.cfn.yml
@@ -1,0 +1,27 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: IAM user with read-only access to CloudWatch and store credentials in SSM
+
+Resources:
+  CWReadOnlyUser:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: CWReadOnlyUser
+      ManagedPolicyArns:
+        - arn:aws-us-gov:iam::aws:policy/CloudWatchReadOnlyAccess
+  CWUserAccessKey:
+    Type: AWS::IAM::AccessKey
+    Properties:
+      UserName: !Ref CWReadOnlyUser
+  SecretKeySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: /jwcc/deployment/cw_user
+      Description: "Access and Secret keys for CloudWatch Read-Only User"
+      SecretString: !Join
+        - ""
+        - - '{"AccessKey":"'
+          - !Ref CWUserAccessKey
+          - '","SecretKey":"'
+          - !GetAtt CWUserAccessKey.SecretAccessKey
+          - '"}'

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,7 @@ deploy-vpc-dev = { run = "aws cloudformation deploy --template-file 01_vpc.cfn.y
 deploy-cloudtrail = { run = "aws cloudformation deploy --template-file 02_cloudtrail.cfn.yml --stack-name jwcc-cloudtrail" }
 deploy-vm-artifacts = { run = "aws cloudformation deploy --template-file 03_vm_artifacts.cfn.yml --stack-name jwcc-vm-artifacts" }
 import-ami-dev = { run = "aws cloudformation deploy --template-file 04_restore_image_task.cfn.yml --stack-name jwcc-ami-import --capabilities CAPABILITY_IAM" }
+deploy-monitoring = { run = "aws cloudformation deploy --template-file 06_monitoring.cfn.yml --stack-name jwcc-monitoring --capabilities CAPABILITY_NAMED_IAM" }
 
 [tasks.deploy-all]
 description = "Deploy all Cloudformation stacks."


### PR DESCRIPTION
## What is the motivation behind this PR?
We are looking to use Grafana as our single pane of glass into the greater over-all system, including AWS. As such we need the ability to view CloudWatch metrics from Grafana, which means we need credentials to do so. It was decided to use a IAM user and manually provision the source, as opposed to an IAM role on the EC2 instance, as we don't want any pod in the cluster to be able to pull from cloudwatch.

## Summary of changes
* Create IAM user and store in SecretsManager.

## Author reminders
- [x] Reviewed my own PR
- [ ] Updated documentation, if applicable
