### PR TITLE
docs: standardize PR template [DEV-436]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,14 @@
 ## What is the motivation behind this PR?
 
-<!-- how does this benefit our customers or dev team? -->
+<!-- What problem existed before this PR? -->
+<!-- How does this benefit our customers or dev team? -->
 
 ## Summary of changes
 
-<!-- give a helpful summary of changes for the reviewer -->
+<!-- How does this PR fix the above problem statement -->
+<!-- Give a helpful summary of changes for the reviewer -->
 
-## Author reminders
-- [ ] Reviewed my own PR
-- [ ] Updated documentation, if applicable
+## How to Test
+
+<!-- How does the reviewer validate the problem existed before -->
+<!-- and is now resolved after -->


### PR DESCRIPTION
## What is the motivation behind this PR?

PR templates for devops/sre-owned repositories are not standardized and have unused sections.

## Summary of changes

- Update the template to one that is standard across devops/sre-owned repositories
- Removed "Miscellaneous" and "Author Reminders"
- Added "How to Test" to repos that did not have it.

## How to Test

Compare `.github/pull_request_template.md` in default branch to this PR.
